### PR TITLE
Fix a typo in docs README

### DIFF
--- a/doc/Readme.md
+++ b/doc/Readme.md
@@ -1,1 +1,1 @@
-An empty stub for docuemtnation
+An empty stub for documentation


### PR DESCRIPTION
Documentation was misspelled. This fixes it.
