### PR TITLE
Update Test_IO.cpp

### DIFF
--- a/src/Test_IO.cpp
+++ b/src/Test_IO.cpp
@@ -13,7 +13,7 @@
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
  */
-#include "NTL/zz_pX.h"
+#include <NTL/ZZX.h>
 #include "FHE.h"
 #include "timing.h"
 #include "EncryptedArray.h"
@@ -109,7 +109,7 @@ int main(int argc, char *argv[])
 
   // open file for read
   {fstream keyFile("iotest.txt", fstream::in);
-  for (long i=0; i<(long)(sizeof(ms)/sizeof(int[4])); i++) {
+  for (long i=0; i<N_TESTS; i++) {
 
     // Read context from file
     unsigned long m1, p1, r1;


### PR DESCRIPTION
1) Line #16: #include <NTL/ZZX.h> instead of "NTL/zz_pX.h"
2) Line #112: for (long i=0; i<(long)(sizeof(ms)/sizeof(int[4])); i++) causes the program to attempt fetching more keys which result in a similar error I had (Searching for cc='[' (ascii....), so I changed it to N_TESTS, since that is the total # of tests being executed. But I am not sure if that is correct.
