### PR TITLE
Avoid using the TR1 namespace

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -14,7 +14,8 @@
 # 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 # 
 CC = g++
-CFLAGS = -g -Wall -I/usr/local/include -std=c++11
+CFLAGS = -g -Wall -I/usr/local/include -std=c++11 -lstdc++
+
 #CFLAGS = -g -O2  -Wfatal-errors -Wshadow -Wall -I/usr/local/include 
 #CFLAGS = -g -Wfatal-errors -Wshadow -Wall -I/usr/local/include 
 #CFLAGS= -g -O2 -Wfatal-errors -Wshadow -Wall -I/usr/local/include -DUSE_ALT_CRT

--- a/src/timing.cpp
+++ b/src/timing.cpp
@@ -16,7 +16,7 @@
 #include <ctime>
 #include <iostream>
 #include "timing.h"
-#include <tr1/unordered_map>
+#include <unordered_map>
 #include <vector>
 #include <algorithm>
 #include <utility>
@@ -43,7 +43,7 @@ bool string_compare(const char *a, const char *b)
 
 bool FHEtimersOn=false;
 
-typedef tr1::unordered_map<const char*,FHEtimer>timerMap;
+typedef std::unordered_map<const char*,FHEtimer>timerMap;
 static timerMap timers;
 
 // Reset a timer for some label to zero


### PR DESCRIPTION
Users of OS X Mavricks live in a world without 'tr1' so lets all switch to libstdc++ and std=c++11.  The alternatives seem to be either leave out Mac 10.9 or use CPP - neither of which are appealing.
