### PR TITLE
Fix the bug for outputting FHEcontext object w/o sign indicators of ords

### DIFF
--- a/src/FHE.cpp
+++ b/src/FHE.cpp
@@ -471,7 +471,7 @@ istream& operator>>(istream& str, FHEPubKey& pk)
   assert( gens.size() == pk.getContext().zMStar.numOfGens() );
   for (long i=0; i<(long)gens.size(); i++)
     assert(gens[i]==(long)pk.getContext().zMStar.ZmStarGen(i) 
-	   && ords[i]==(long) pk.getContext().zMStar.OrderOf(i));
+	   && ords[i]==(long) pk.getContext().zMStar.OrderOf4IO(i));
 
   // Get the public encryption key itself
   str >> pk.pubEncrKey;

--- a/src/FHEContext.cpp
+++ b/src/FHEContext.cpp
@@ -386,7 +386,7 @@ void writeContextBase(ostream& str, const FHEcontext& context)
   }
   str << " [";
   for (long i=0; i<(long) context.zMStar.numOfGens(); i++) {
-    str << context.zMStar.OrderOf(i)
+    str << context.zMStar.OrderOf4IO(i)
 	<< ((i==(long)context.zMStar.numOfGens()-1)? "]" : " ");
   }
   str << "]";

--- a/src/PAlgebra.h
+++ b/src/PAlgebra.h
@@ -148,6 +148,10 @@ class PAlgebra {
   unsigned long OrderOf(unsigned long i) const
   {  return (i<ords.size())? abs(ords[i]) : 0; }
 
+  //! The order of i'th generator (if any) with sign indicator (good/bad) for the purpose of I/O
+  long OrderOf4IO(unsigned long i) const
+  {  return (i<ords.size())? ords[i] : 0; }
+
   //! Is ord(i'th generator) the same as its order in (Z/mZ)^*? 
   bool SameOrd(unsigned long i) const
   {  return (i<ords.size())? (ords[i]>0) : false; }


### PR DESCRIPTION
Current implementation outputs bad generators as good generators.

When a FHEcontext object is loaded from some dumped FHEcontext, the following functions fail
since `al.SameOrd(i)` returns always true even if a generator for a certain dimension is bad.

* `EncryptedArrayDerived<type>::rotate1D(Ctxt& ctxt, long i, long amt, bool dc)` 
* `EncryptedArrayDerived<type>::rotate(Ctxt& ctxt, long amt)` 


I have appended `long PAlgebra::OrderOf4IO` which outputs `vector<long> ords` in correct format and is called only for IO purpose.