### PR TITLE
Fixed incorrect Makefile definition with check_Bin_IO_x

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -66,7 +66,7 @@ check:
 	$(MAKE) check_binaryArith
 	$(MAKE) check_binaryCompare
 	$(MAKE) check_tableLookup
-	$(MAKE) check_Test_Bin_IO_x
+	$(MAKE) check_Bin_IO_x
 
 check_General: Test_General_x 
 	./Test_General_x R=1 k=10 p=2 r=2 noPrint=1


### PR DESCRIPTION
`check_Bin_IO_x` is not working for an incorrect definition with Makefile at "src" directory.
It'll work with this merge.