### PR TITLE
Removed Unused Variables

### DIFF
--- a/src/CModulus.cpp
+++ b/src/CModulus.cpp
@@ -284,7 +284,7 @@ void BasicBitReverseCopy(long * NTL_RESTRICT B,
 
    long n = 1L << k;
    long* NTL_RESTRICT rev;
-   long i, j;
+   long i;
 
    rev = brc_mem[k].elts();
    if (!rev) rev = BRC_init(k);
@@ -307,7 +307,6 @@ void COBRA(long * NTL_RESTRICT B, const long * NTL_RESTRICT A, long k)
    long * NTL_RESTRICT rev_k1, * NTL_RESTRICT rev_q;
    long *NTL_RESTRICT T;
    long a, b, c, a1, b1, c1;
-   long i, j;
 
    rev_k1 = brc_mem[k1].elts();
    if (!rev_k1) rev_k1 = BRC_init(k1);


### PR DESCRIPTION
Using the flag -Wunused-variable during compilation of the src, there are multiple instances where variables are not used in a function. This also includes some variables that store a function's return value and those are flagged as well. I am unsure about if these are there for later use. This modification is the beginning the warnings along with many others. Lastly, using -Wall, there are warnings about virtual functions override. Are these a big issue and how could these warnings be taken care of? 