### PR TITLE
Fixed typo in Install... Fix in line 167: ./configure NTL_GMP_LIP=on …

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -164,7 +164,7 @@ You can install NTL as follows:
 3. NTL is configured, built and installed in the standard Unix way (but
 remember to specify the following flags to `configure`):
 ```
-      ./configure NTL_GMP_LIP=ON SHARED=on
+      ./configure NTL_GMP_LIP=on SHARED=on
       make
       sudo make install
 ```


### PR DESCRIPTION
Changed `./configure NTL_GMP_LIP=ON` to `./configure NTL_GMP_LIP=on`, as it was breaking the NTL config script. This is in the `INSTALL.md` file.