### PR TITLE
Homo AES compatible

### DIFF
--- a/misc/aes/CMakeLists.txt
+++ b/misc/aes/CMakeLists.txt
@@ -1,2 +1,14 @@
+cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
+## Use -std=c++14 as default.
+set(CMAKE_CXX_STANDARD 14)
+## Disable C++ extensions
+set(CMAKE_CXX_EXTENSIONS OFF)
+## Require full C++ standard
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+project(Test_AES_example
+        LANGUAGES CXX)
+
+find_package(helib 1.0.0 EXACT REQUIRED)
 add_executable(TEST_AES simpleAES.cpp homAES.cpp Test_AES.cpp)
 target_link_libraries(TEST_AES PUBLIC helib)

--- a/misc/aes/homAES.h
+++ b/misc/aes/homAES.h
@@ -3,8 +3,8 @@
 #include <stdint.h>
 #include <NTL/ZZX.h>
 #include <NTL/GF2X.h>
-#include "EncryptedArray.h"
-#include "hypercube.h"
+#include "helib/EncryptedArray.h"
+#include "helib/hypercube.h"
 
 #ifdef USE_ZZX_POLY
 #define PolyType ZZX

--- a/misc/aes/simpleAES.cpp
+++ b/misc/aes/simpleAES.cpp
@@ -33,6 +33,7 @@ http://en.wikipedia.org/wiki/Advanced_Encryption_Standard
 // Used for giving output to the screen.
 #include<cstdlib>
 #include<cstdio>
+#include<helib/helib.h>
 
 // The number of columns comprising a state in AES. This is a constant in AES.
 // Value=4


### PR DESCRIPTION
After lots of updates of HElib, it seems that homo AES has several places which are not complatible. This PR tried to make homo AES work with the latest helib.

Some places to modify are:
1. replace L(number of level) with N(nuber of bits) in the modulus chain to be compatible with `buildModChain`
2. helib namespace and include files
3. `findBaseLevel` modify
4. `CMakeLists.txt` modify

The running cases are:
```
./TEST_AES boot=1 sz=3 N=800
./TEST_AES boot=0 sz=4 N=1600
```