### PR TITLE
Add Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: cpp
+
+os: 
+  - osx
+compiler: 
+  - clang
+
+# Install the necessary dependencies.
+addon:
+  homebrew:
+    packages: 
+      - ntl
+    update: true
+
+# Run the build script
+script: ./ci/travis.sh

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 HElib
 =====
 
+[![Build Status](https://travis-ci.com/Jyun-Neng/HElib.svg?branch=master)](https://travis-ci.com/Jyun-Neng/HElib)
+
 HElib is an open-source ([Apache License v2.0][5]) software library that 
 implements [homomorphic encryption][6] (HE). Currently available schemes 
 are the implementations of the [Brakerski-Gentry-Vaikuntanathan][1] (BGV) 

--- a/ci/travis.sh
+++ b/ci/travis.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -ev
+
+# if possible, ask for the precise number of processors,
+# otherwise take 2 processors as reasonable default.
+if [ -x /usr/bin/getconf ]; then
+    NPROCESSORS=$(/usr/bin/getconf _NPROCESSORS_ONLN)
+else
+    NPROCESSORS=2
+fi
+
+MAKEFLAGS="j${NPROCESSORS}"
+export MAKEFLAGS
+
+mkdir build
+cd build
+
+cmake -DENABLE_TEST=ON ..
+make 
+make test


### PR DESCRIPTION
Apply CI to keep integrating the code in this project. This can automatically check if HElib could be successfully built. So far, it has passed `make test` on OSX.