### PR TITLE
Use CLOCK_MONOTONIC if CLOCK_MONOTONIC_RAW is not defined.

### DIFF
--- a/src/timing.cpp
+++ b/src/timing.cpp
@@ -18,6 +18,11 @@
 namespace helib {
 
 #ifdef CLOCK_MONOTONIC
+
+#ifndef CLOCK_MONOTONIC_RAW
+#define CLOCK_MONOTONIC_RAW CLOCK_MONOTONIC
+#endif
+
 unsigned long GetTimerClock()
 {
   timespec ts;


### PR DESCRIPTION
NetBSD only provides CLOCK_MONOTONIC.