### PR TITLE
Small performance improvements and cleanup

### DIFF
--- a/include/helib/ArgMap.h
+++ b/include/helib/ArgMap.h
@@ -499,7 +499,7 @@ ArgMap& ArgMap::arg(const std::string& name, T& value)
 
   // have we seen this addr before?
   assertEq<LogicError>(addresses_used.count(&value),
-                       0ul,
+                       static_cast<std::size_t>(0),
                        "Attempting to register variable twice");
 
   addresses_used.insert(&value);

--- a/include/helib/PAlgebra.h
+++ b/include/helib/PAlgebra.h
@@ -519,7 +519,7 @@ std::shared_ptr<TNode<T>> buildTNode(std::shared_ptr<TNode<T>> left,
                                      std::shared_ptr<TNode<T>> right,
                                      const T& data)
 {
-  return std::shared_ptr<TNode<T>>(new TNode<T>(left, right, data));
+  return std::make_shared<TNode<T>>(left, right, data);
 }
 
 template <typename T>

--- a/src/Context.cpp
+++ b/src/Context.cpp
@@ -364,7 +364,7 @@ void readContextBinary(std::istream& str, Context& context)
   for (long p, i = 0; i < nPrimes; i++) {
     p = read_raw_int(str);
 
-    context.moduli.push_back(Cmodulus(context.zMStar, p, 0));
+    context.moduli.emplace_back(context.zMStar, p, 0);
 
     if (smallPrimes.contains(i))
       context.smallPrimes.insert(i); // small prime
@@ -512,7 +512,7 @@ std::istream& operator>>(std::istream& str, Context& context)
     long p;
     str >> p;
 
-    context.moduli.push_back(Cmodulus(context.zMStar, p, 0));
+    context.moduli.emplace_back(context.zMStar, p, 0);
 
     if (smallPrimes.contains(i))
       context.smallPrimes.insert(i); // small prime

--- a/src/Context.cpp
+++ b/src/Context.cpp
@@ -278,7 +278,7 @@ std::unique_ptr<Context> buildContextFromBinary(std::istream& str)
   unsigned long m, p, r;
   std::vector<long> gens, ords;
   readContextBaseBinary(str, m, p, r, gens, ords);
-  return std::unique_ptr<Context>(new Context(m, p, r, gens, ords));
+  return std::make_unique<Context>(m, p, r, gens, ords);
 }
 
 void writeContextBinary(std::ostream& str, const Context& context)
@@ -482,7 +482,7 @@ std::unique_ptr<Context> buildContextFromAscii(std::istream& str)
   unsigned long m, p, r;
   std::vector<long> gens, ords;
   readContextBase(str, m, p, r, gens, ords);
-  return std::unique_ptr<Context>(new Context(m, p, r, gens, ords));
+  return std::make_unique<Context>(m, p, r, gens, ords);
 }
 
 std::istream& operator>>(std::istream& str, Context& context)

--- a/src/Ctxt.cpp
+++ b/src/Ctxt.cpp
@@ -727,7 +727,7 @@ void Ctxt::addPart(const DoubleCRT& part,
     // meaning that the value of primeSet for an "empty" ciphertext
     // is irrelevant.
 
-    parts.push_back(CtxtPart(part, handle));
+    parts.emplace_back(part, handle);
     if (negative)
       parts.back().Negate();
   } else { // adding to a ciphertext with existing parts
@@ -782,7 +782,7 @@ void Ctxt::addPart(const DoubleCRT& part,
       else
         parts[j].Add(*ptr, /*matchIndexSets=*/false);
     } else { // no matching part found, just append this part
-      parts.push_back(CtxtPart(*ptr, handle));
+      parts.emplace_back(*ptr, handle);
       if (negative)
         parts.back().Negate();
     }

--- a/src/OptimizePermutations.cpp
+++ b/src/OptimizePermutations.cpp
@@ -165,7 +165,14 @@ void buildBenesCostTable(long n,
 //! \cond FALSE (make doxygen ignore these classes)
 class LongNode;
 typedef std::shared_ptr<LongNode> LongNodePtr;
-// A "shared_ptr" is a pointer with (some) garbage collection
+// A "std::shared_ptr" is a pointer with (some) garbage collection
+
+template <typename... Args>
+LongNodePtr MakeLongNodePtr(Args&&... args)
+{
+  return std::make_shared<LongNode>(std::forward<Args>(args)...);
+}
+// Thin wrapper around "std::make_shared" for LongNodePtr
 
 // A LongNode is an implementation of std::list<long>, i.e. a linked list of
 // counters, representing a particular way of "collapsing levels" in a Benes
@@ -315,7 +322,7 @@ BenesMemoEntry optimalBenesAux(long i,
     // all remaining levels together.
 
     cost = costTab[i][nlev - i - 1];
-    solution = LongNodePtr(new LongNode(nlev - i, LongNodePtr()));
+    solution = MakeLongNodePtr(nlev - i, LongNodePtr());
   } else {
     // We consider collapsing levels i..i+j, for all j in [0..nlev-i),
     // then choose the option that gives the best cost.
@@ -339,7 +346,7 @@ BenesMemoEntry optimalBenesAux(long i,
     }
 
     cost = bestCost;
-    solution = LongNodePtr(new LongNode(bestJ + 1, bestT.solution));
+    solution = MakeLongNodePtr(bestJ + 1, bestT.solution);
   }
 
   return memoTab[BenesMemoKey(i, budget)] = BenesMemoEntry(cost, solution);
@@ -388,6 +395,13 @@ void optimalBenes(long n,
 class SplitNode;
 typedef std::shared_ptr<SplitNode> SplitNodePtr;
 // A "std::shared_ptr" is a pointer with (some) garbage collection
+
+template <typename... Args>
+SplitNodePtr MakeSplitNodePtr(Args&&... args)
+{
+  return std::make_shared<SplitNode>(std::forward<Args>(args)...);
+}
+// Thin wrapper around "std::make_shared" for SplitNodePtr
 
 class SplitNode
 {
@@ -521,7 +535,14 @@ typedef std::
 
 class GenNode;
 typedef std::shared_ptr<GenNode> GenNodePtr;
-// A "shared_ptr" is a pointer with (some) garbage collection
+// A "std::shared_ptr" is a pointer with (some) garbage collection
+
+template <typename... Args>
+GenNodePtr MakeGenNodePtr(Args&&... args)
+{
+  return std::make_shared<GenNode>(std::forward<Args>(args)...);
+}
+// Thin wrapper around "std::make_shared" for GenNodePtr
 
 class GenNode
 {
@@ -674,8 +695,8 @@ LowerMemoEntry optimalLower(long order,
     }
 
     // The initial solution corresponds to this being a leaf node
-    solution = SplitNodePtr(
-        new SplitNode(order, mid, good, benesSolution1, benesSolution2));
+    solution = MakeSplitNodePtr(
+        order, mid, good, benesSolution1, benesSolution2);
 
     // Recursively try all the ways of splitting order = order1 * order2
 
@@ -722,8 +743,8 @@ LowerMemoEntry optimalLower(long order,
               s1.cost + s2.cost < cost) {
             cost = s1.cost + s2.cost;
             // Record the new best solution
-            solution = SplitNodePtr(
-                new SplitNode(order, mid, good, s1.solution, s2.solution));
+            solution = MakeSplitNodePtr(
+                order, mid, good, s1.solution, s2.solution);
           }
         }
       }
@@ -812,7 +833,7 @@ UpperMemoEntry optimalUpperAux(const NTL::Vec<GenDescriptor>& vec,
     if (cost == NTL_MAX_LONG)
       solution = GenNodePtr();
     else
-      solution = GenNodePtr(new GenNode(bestS.solution, bestT.solution));
+      solution = MakeGenNodePtr(bestS.solution, bestT.solution);
   }
 
   // Record the best solution in the upperMemoTable and return it

--- a/src/PGFFT.cpp
+++ b/src/PGFFT.cpp
@@ -1216,9 +1216,8 @@ void BasicBitReverseCopy(cmplx_t *B,
                          const cmplx_t *A, long k, const vector<long>& rev)
 {
    long n = 1L << k;
-   long i, j;
 
-   for (i = 0; i < n; i++)
+   for (long i = 0; i < n; i++)
       B[rev[i]] = A[i];
 }
 

--- a/src/PolyMod.cpp
+++ b/src/PolyMod.cpp
@@ -322,12 +322,12 @@ void serialize(std::ostream& os, const PolyMod& poly)
   }
 
   // TODO: Add stream modifier option for separator
-  std::string sep = ", ";
+  constexpr char sep[] = ", ";
   os << "[";
   for (auto ite = poly.data.rep.begin(); ite != poly.data.rep.end(); ++ite) {
     os << *ite;
     if (ite + 1 != poly.data.rep.end()) {
-      os << ", ";
+      os << sep;
     }
   }
   os << "]";

--- a/src/binaryArith.cpp
+++ b/src/binaryArith.cpp
@@ -987,7 +987,7 @@ static void multByNegative(CtPtrs& product,
     for (long j = i; j < resSize; j++)
       if (j < i + lsize(b) && a.isSet(i) && !a[i]->isEmpty() &&
           b.isSet(j - i) && !b[j - i]->isEmpty()) {
-        pairs.push_back(std::pair<long, long>(i, j));
+        pairs.emplace_back(i, j);
       }
   long nPairs = lsize(pairs);
 
@@ -1093,7 +1093,7 @@ void multTwoNumbers(CtPtrs& product,
     for (long j = i; j < lsize(numbers[i]); j++) {
       if (lhs.isSet(j - i) && !(lhs[j - i]->isEmpty()) && rhs.isSet(i) &&
           !(rhs[i]->isEmpty()))
-        pairs.push_back(std::pair<long, long>(i, j));
+        pairs.emplace_back(i, j);
     }
   long nPairs = lsize(pairs);
   NTL_EXEC_RANGE(nPairs, first, last)

--- a/src/keys.cpp
+++ b/src/keys.cpp
@@ -134,7 +134,7 @@ void PubKey::setKeySwitchMap(long keyId)
     const KeySwitch& mat = keySwitching.at(i);
     if (mat.toKeyID == keyId && mat.fromKey.getPowerOfS() == 1 &&
         mat.fromKey.getSecretKeyID() == keyId)
-      edges.push_back(keySwitchingEdge(mat.fromKey.getPowerOfX(), i));
+      edges.emplace_back(mat.fromKey.getPowerOfX(), i);
   }
   if (keyId >= (long)keySwitchMap.size()) // allocate more space if needed
     keySwitchMap.resize(keyId + 1);

--- a/src/norms.cpp
+++ b/src/norms.cpp
@@ -501,7 +501,7 @@ void CKKS_canonicalEmbedding(std::vector<cx_double>& v,
   long sz = in.size();
   long m = palg.getM();
 
-  if (!(palg.getP() == -1 && palg.getPow2() >= 2 && sz <= m / 2))
+  if (!(palg.getP() == -1 && palg.getPow2() >= 2 && sz < m / 2))
     throw LogicError("bad args to CKKS_canonicalEmbedding");
 
   const half_FFT& hfft = palg.getHalfFFTInfo();

--- a/src/primeChain.cpp
+++ b/src/primeChain.cpp
@@ -72,7 +72,7 @@ void ModuliSizes::init(const Context& context)
 
   // Get all subsets of smallPrimes
 
-  sizes.push_back(std::make_pair(0.0, IndexSet::emptySet())); // the empty set
+  sizes.emplace_back(0.0, IndexSet::emptySet()); // the empty set
   long idx = 1; // first index that's still not set
 
   for (long i : context.smallPrimes) { // add i to all sets upto idx-1
@@ -451,7 +451,7 @@ void Context::AddSmallPrime(long q)
 {
   assertFalse(inChain(q), "Small prime q is already in the prime chain");
   long i = moduli.size(); // The index of the new prime in the list
-  moduli.push_back(Cmodulus(zMStar, q, 0));
+  moduli.emplace_back(zMStar, q, 0);
   smallPrimes.insert(i);
 }
 
@@ -459,7 +459,7 @@ void Context::AddCtxtPrime(long q)
 {
   assertFalse(inChain(q), "Prime q is already in the prime chain");
   long i = moduli.size(); // The index of the new prime in the list
-  moduli.push_back(Cmodulus(zMStar, q, 0));
+  moduli.emplace_back(zMStar, q, 0);
   ctxtPrimes.insert(i);
 }
 
@@ -467,7 +467,7 @@ void Context::AddSpecialPrime(long q)
 {
   assertFalse(inChain(q), "Special prime q is already in the prime chain");
   long i = moduli.size(); // The index of the new prime in the list
-  moduli.push_back(Cmodulus(zMStar, q, 0));
+  moduli.emplace_back(zMStar, q, 0);
   specialPrimes.insert(i);
 }
 

--- a/src/tapprox.cpp
+++ b/src/tapprox.cpp
@@ -411,7 +411,7 @@ int main(int argc, char* argv[])
     secretKey.GenSecKey();        // A +-1/0 secret key
     addSome1DMatrices(secretKey); // compute key-switching matrices
 
-    const PubKey publicKey = secretKey;
+    const PubKey &publicKey = secretKey;
     const EncryptedArrayCx& ea = context.ea->getCx();
 
     if (verbose) {

--- a/src/zzX.cpp
+++ b/src/zzX.cpp
@@ -95,7 +95,7 @@ const NTL::zz_pXModulus& getPhimXMod(const PAlgebra& palg)
         new NTL::zz_pXModulus(phimX); // will "never" be deleted
 
     // insert returns a pair (iterator, bool)
-    auto ret = moduli.insert(std::pair<long, NTL::zz_pXModulus*>(m, ptr));
+    auto ret = moduli.emplace(m, ptr);
     if (ret.second == false) // Another thread inserted it, delete your copy
       delete ptr;
     // FIXME: Could leak memory if insert throws an exception


### PR DESCRIPTION
* `size_t` is not always same as `unsigned long`.
* Emplace in container instead of insert for performance.
* Do not slice derived type `SecKey` on base one `PubKey`.
* Use `make_{unique|shared}` and wrappers for exception safety and performance.

Unfortunately, can't check changes via tests, as have Windows machine.
Could you, please, check test results for me :)?

Also, using some CI tool like https://travis-ci.org/ + pull request hook make tests
checking much more easier and disallows merging of broken changes.

Signed-off-by: Dmitry Tsarevich <dimhotepus@gmail.com>