### PR TITLE
Small typo fix in NTL configure command

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -186,7 +186,7 @@ You can install NTL as follows:
 3. NTL is configured, built and installed in the standard Unix way (but
 remember to specify the following flags to `configure`):
 ```
-      ./configure NTL_GMP_LIP=ON SHARED=on  NTL_THREADS=on NTL_THREAD_BOOST=on
+      ./configure NTL_GMP_LIP=on SHARED=on  NTL_THREADS=on NTL_THREAD_BOOST=on
       make
       sudo make install
 ```


### PR DESCRIPTION
Just a tiny typo in INSTALL.md: 
At least on my system, configure refused to parse the all-caps "ON"