### PR TITLE
Travis-ci whitelisting master branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,11 @@ language: cpp
 notifications:
   email: false
 sudo: required
+
+branches:
+  only:
+  - master
+
 before_script:
   # 
   - curl -O "https://www.shoup.net/ntl/ntl-11.4.3.tar.gz"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,40 @@
+language: cpp
+notifications:
+  email: false
+sudo: required
+before_script:
+  # 
+  - curl -O "https://www.shoup.net/ntl/ntl-11.4.3.tar.gz"
+  - tar --no-same-owner -xf ntl-11.4.3.tar.gz
+  - cd ntl-11.4.3/src
+  - ./configure PREFIX=~/ntl SHARED=on NTL_GMP_LIP=on NTL_THREADS=on NTL_THREAD_BOOST=on
+  - make -j4
+  - make install
+  - cd ../..
+
+  # Build Folder
+  #
+  - mkdir build
+  - cd build
+
+matrix:
+  include:
+  - os: linux
+    dist: bionic
+    env:
+      - TEST="Build test"
+    addons:
+      apt:
+        sources:
+          - ubuntu-toolchain-r-test
+        packages:
+          - gcc
+          - g++
+          - m4
+          - patchelf
+
+
+script:
+      - cmake -DPACKAGE_BUILD=OFF -DNTL_DIR="/home/travis/ntl/" -DENABLE_TEST=ON .. 
+      - make -j4
+      - ctest -j4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,9 +87,6 @@ if (PACKAGE_BUILD)
   option(FETCH_GMP "Fetch and compile the GMP library (DEFAULT: ON)" ON)
 else (PACKAGE_BUILD)
   # Properties to be enabled when not using PACKAGE_BUILD
-  option(ENABLE_LEGACY_TEST
-         "Build the legacy test files (does not work with PACKAGE_BUILD)"
-         OFF)
 endif (PACKAGE_BUILD)
 
 # Allow GMP_DIR and search in it if not using PACKAGE_BUILD or using
@@ -296,7 +293,6 @@ if (PACKAGE_BUILD)
                -DFETCH_GMP=${FETCH_GMP}
                -DENABLE_TEST=${ENABLE_TEST}
                -DHELIB_DEBUG=${HELIB_DEBUG}
-               -DENABLE_LEGACY_TEST=OFF
     BUILD_ALWAYS ON)
 
   if (ENABLE_TEST)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -232,8 +232,6 @@ set to `OFF`, there should either exist a system-installed GMP library, or
 - `GMP_DIR`: Prefix of the GMP library.  Ignored if `FETCH_GMP=ON`.
 
 ### Parameters specific to option 2 (library build)
-- `ENABLE_LEGACY_TEST=ON/OFF` (default is `OFF`): Build old test system 
-  (deprecated).
 - `GMP_DIR`: Prefix of the GMP library.
 - `NTL_DIR`: Prefix of the NTL library.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 HElib
 =====
+[![Build Status](https://travis-ci.com/helibproject/HElib.svg?branch=master)](https://travis-ci.com/helibproject/HElib)
 
 HElib is an open-source ([Apache License v2.0][5]) software library that 
 implements [homomorphic encryption][6] (HE). Currently available schemes 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -173,33 +173,6 @@ set(HELIB_HEADERS
     "${HELIB_HEADER_DIR}/fhe_stats.h"
     "${HELIB_HEADER_DIR}/zeroValue.h")
 
-set(LEGACY_TEST_SRCS
-    "Test_approxNums.cpp"
-    "Test_binaryArith.cpp"
-    "Test_binaryCompare.cpp"
-    "Test_Bin_IO.cpp"
-    "Test_bootstrapping.cpp"
-    "Test_EaCx.cpp"
-    "Test_EvalMap.cpp"
-    "Test_extractDigits.cpp"
-    "Test_General.cpp"
-    "Test_intraSlot.cpp"
-    "Test_IO.cpp"
-    "Test_matmul.cpp"
-    "Test_PAlgebra.cpp"
-    "Test_Permutations.cpp"
-    "Test_PolyEval.cpp"
-    "Test_Powerful.cpp"
-    "Test_PtrVector.cpp"
-    "Test_Replicate.cpp"
-    "Test_tableLookup.cpp"
-    "Test_ThinBootstrapping.cpp"
-    "Test_ThinEvalMap.cpp"
-    "Test_Timing.cpp"
-    "Test_thinboot.cpp"
-    "Test_fatboot.cpp"
-    "Test_PGFFT.cpp")
-
 # Add helib target as a shared/static library
 if (BUILD_SHARED)
   add_library(helib SHARED ${HELIB_SRCS} ${HELIB_HEADERS})
@@ -310,17 +283,6 @@ if (BUILD_SHARED)
                             SKIP_BUILD_RPATH OFF
                             BUILD_WITH_INSTALL_RPATH OFF)
 endif (BUILD_SHARED)
-
-if (ENABLE_LEGACY_TEST)
-  foreach (TEST_FILE ${LEGACY_TEST_SRCS})
-    string(REPLACE "\.cpp" "" TEST_NAME "${TEST_FILE}")
-    add_executable(${TEST_NAME} ${TEST_FILE})
-    # NOTE: Legacy tests depend only on HElib.
-    # HElib's PUBLIC attributes will be added automatically when setting HElib
-    # as a dependency.
-    target_link_libraries(${TEST_NAME} helib)
-  endforeach (TEST_FILE)
-endif (ENABLE_LEGACY_TEST)
 
 if (ENABLE_TEST)
   add_subdirectory("${PROJECT_TESTS_DIR}" tests)


### PR DESCRIPTION
Whitelisted only the `master` branch, so no build will happen on other branches.
This does not stop PR builds.