### PR TITLE
Remove unused printPoly method from BGV_country_db_lookup.cpp

### DIFF
--- a/examples/BGV_country_db_lookup/BGV_country_db_lookup.cpp
+++ b/examples/BGV_country_db_lookup/BGV_country_db_lookup.cpp
@@ -27,18 +27,6 @@
 #include <helib/ArgMap.h>
 #include <NTL/BasicThreadPool.h>
 
-// Utility function to print polynomials
-void printPoly(NTL::ZZX& poly)
-{
-  for (int i = NTL::deg(poly); i >= 0; i--) {
-    std::cout << poly[i] << "x^" << i;
-    if (i > 0)
-      std::cout << " + ";
-    else
-      std::cout << "\n";
-  }
-}
-
 // Utility function to read <K,V> CSV data from file
 std::vector<std::pair<std::string, std::string>> read_csv(std::string filename)
 {


### PR DESCRIPTION
The `printPoly` in BGV_country_db_lookup.cpp was added in [this commit](https://github.com/homenc/HElib/commit/069751b2adfd1ca755bae2d1840148c1794ec385) but isn't used in this file.