### PR TITLE
Removed typo from gen-params.batx

### DIFF
--- a/misc/psi/tests/gen-params.batx
+++ b/misc/psi/tests/gen-params.batx
@@ -78,7 +78,7 @@ function create-serious-lookup-params {
 #  create-toy-lookup-params
   create-serious-lookup-params
   createContext BGV "${prefix_bgv}.params" "$prefix_bgv" "--frob-skm"
-  techo "$(cat ${prefix_bgv}.info)"
+  echo "$(cat ${prefix_bgv}.info)"
 }
 
 @test "generate params and encrypt query and database" {


### PR DESCRIPTION
Removed an extra "t" which was a typo conflicting with echo command.