### PR TITLE
Ctxt::addConstantCKKS: Use type long for denominator

### DIFF
--- a/include/helib/Ctxt.h
+++ b/include/helib/Ctxt.h
@@ -654,7 +654,7 @@ public:
   void addConstantCKKS(double x)
   { // FIXME: not enough precision when x is large
     addConstantCKKS(
-        rationalApprox(x, /*denomBound=*/1 << getContext().getAlMod().getR()));
+        rationalApprox(x, /*denomBound=*/1L << getContext().getAlMod().getR()));
   }
 
   // [[deprecated]]


### PR DESCRIPTION
Small bug in `Ctxt::addConstantCKKS(double x)` -- if the value of `r` is bigger than 30, then the left-shift is an undefined behavior.

The fix converts the 1 to long so that we can shift-left by all allowed values of `r` (the allowed range is 1 to 59).
