### PR TITLE
Fix minor compile issues with single-threading

### DIFF
--- a/src/recryption.cpp
+++ b/src/recryption.cpp
@@ -707,7 +707,7 @@ void extractDigitsPacked(Ctxt& ctxt,
 
   // Step 3: re-pack the slots
   HELIB_NTIMER_START(repack);
-  const EncryptedArray& ea2 = *ctxt.getContext().ea;
+  const EncryptedArray& ea2 = ctxt.getContext().getEA();
   NTL::ZZX xInSlots;
   std::vector<NTL::ZZX> xVec(ea2.size());
   ctxt = unpacked[0];

--- a/tests/test_common.cpp
+++ b/tests/test_common.cpp
@@ -57,7 +57,11 @@ static inline long howManyThreads(long max = 0)
                            " Zero means use the maximum available on system.");
 
   // Get system threads and clip to max
+#ifdef HELIB_THREADS
   long threads = std::thread::hardware_concurrency();
+#else
+  long threads = 1;
+#endif
   if (max != 0)
     threads = (threads > max) ? max : threads;
 


### PR DESCRIPTION
When building HElib with HELIB_THREADS=OFF (in a profiling setup), I found two minor compile issues in `src/recryption.cpp` and `tests/test_common.cpp`. This patch fixes them.

Signed-off-by: Marius Hillenbrand <mhillen@linux.ibm.com>