### PR TITLE
Deprecated Functions

### DIFF
--- a/examples/BGV_packed_arithmetic/BGV_packed_arithmetic.cpp
+++ b/examples/BGV_packed_arithmetic/BGV_packed_arithmetic.cpp
@@ -164,9 +164,9 @@ int main(int argc, char* argv[])
   // And multiply by constants
   // [1] [1] [1] ... [1] [1]
   // -> [1*1] [1*1] [1*1] ... [1*1] [1*1] = [1] [1] [1] ... [1] [1]
-  ctxt *= NTL::ZZX(1l);
+  ctxt *= 1l;
   // Plaintext version
-  ptxt *= NTL::ZZX(1l);
+  ptxt *= 1l;
 
   // We can also perform ciphertext-plaintext operations
   // ctxt = [1] [1] [1] ... [1] [1], ptxt = [1] [1] [1] ... [1] [1]

--- a/include/helib/Ctxt.h
+++ b/include/helib/Ctxt.h
@@ -611,7 +611,8 @@ public:
    * `EncodedPtxt`-based API.\n
    * Please use `Ctxt::operator*=(const EncodedPtxt& ptxt)` instead.
    **/
-  // [[deprecated]]
+  [[deprecated(
+      "Please use Ctxt::operator*=(const EncodedPtxt& ptxt) instead.")]]
   Ctxt& operator*=(const NTL::ZZX& poly);
 
   //! Add a constant polynomial.
@@ -655,17 +656,21 @@ public:
    * @deprecated This function is deprecated in favor of a newer API.
    * Please use `Ctxt::operator+=(double ptxt)` instead.
    **/
-  // [[deprecated]]
+  [[deprecated("Please use Ctxt::operator+=(double ptxt) instead.")]]
   void addConstantCKKS(std::pair</*numerator=*/long, /*denominator=*/long>);
   /**
    * @deprecated This function is deprecated in favor of a newer API.
    * Please use `Ctxt::operator+=(double ptxt)` instead.
    **/
-  // [[deprecated]]
+  [[deprecated("Please use Ctxt::operator+=(double ptxt) instead.")]]
   void addConstantCKKS(double x)
   { // FIXME: not enough precision when x is large
-    addConstantCKKS(
-        rationalApprox(x, /*denomBound=*/1L << getContext().getAlMod().getR()));
+    // This function is deprecated.
+//    addConstantCKKS(
+//        rationalApprox(x, /*denomBound=*/1L << getContext().getAlMod().getR()));
+    auto p =
+        rationalApprox(x, /*denomBound=*/1L << getContext().getAlMod().getR());
+    *this += double(p.first) / p.second;
   }
 
   /**
@@ -681,7 +686,8 @@ public:
    * @deprecated This function is deprecated in favor of a newer API.
    * Please use `Ctxt::operator+=(const EncodedPtxt& ptxt)` instead.
    **/
-  // [[deprecated]]
+  [[deprecated(
+      "Please use Ctxt::operator+=(const EncodedPtxt& ptxt) instead.")]]
   void addConstantCKKS(const NTL::ZZX& poly,
                        NTL::xdouble size = NTL::xdouble(-1.0),
                        NTL::xdouble factor = NTL::xdouble(-1.0));
@@ -690,7 +696,7 @@ public:
    * @deprecated This function is deprecated in favor of a newer API.
    * Please use `Ctxt::operator+=(const PtxtArray& ptxt)` instead.
    **/
-  // [[deprecated]]
+  [[deprecated("Please use Ctxt::operator+=(const PtxtArray& ptxt) instead.")]]
   void addConstantCKKS(const std::vector<std::complex<double>>& ptxt);
 
   /**
@@ -699,13 +705,14 @@ public:
    * @deprecated This function is deprecated in favor of a newer API.
    * Please use `Ctxt::operator+=(const PtxtArray& ptxt)` instead.
    **/
-  // [[deprecated]]
+  [[deprecated(
+      "Please use Ctxt::operator+=(const Ptxt<Scheme>& ptxt) instead.")]]
   void addConstantCKKS(const Ptxt<CKKS>& ptxt);
   /**
    * @deprecated This function is deprecated in favor of a newer API.
    * Please use `Ctxt::operator+=(const NTL::ZZ& ptxt)` instead.
    **/
-  // [[deprecated]]
+  [[deprecated("Please use Ctxt::operator+=(const NTL::ZZ& ptxt) instead.")]]
   void addConstantCKKS(const NTL::ZZ& c);
 
   //! Multiply-by-constant.
@@ -1094,7 +1101,7 @@ public:
    * @deprecated This function is deprecated in favor of a newer API.
    * Please use `Ctxt::operator*=(double ptxt)` instead.
    **/
-  // [[deprecated]]
+  [[deprecated("Please use Ctxt::operator*=(double ptxt) instead.")]]
   void multByConstantCKKS(double x)
   {
     if (this->isEmpty())
@@ -1119,10 +1126,12 @@ public:
    * @deprecated This function is deprecated in favor of a newer API.
    * Please use `Ctxt::operator*=(double ptxt)` instead.
    **/
-  // [[deprecated]]
+  [[deprecated("Please use Ctxt::operator*=(double ptxt) instead.")]]
   void multByConstantCKKS(std::pair<long, long> num) // rational number
   {
-    multByConstantCKKS(double(num.first) / num.second);
+    // This function is deprecated.
+    // multByConstantCKKS(double(num.first) / num.second);
+    *this *= double(num.first) / num.second;
   }
 
   /**
@@ -1139,7 +1148,8 @@ public:
    * @deprecated This function is deprecated in favor of a newer API.
    * Please use `Ctxt::operator*=(const EncodedPtxt& ptxt)` instead.
    **/
-  // [[deprecated]]
+  [[deprecated(
+      "Please use Ctxt::operator*=(const EncodedPtxt& ptxt) instead.")]]
   void multByConstantCKKS(const NTL::ZZX& poly,
                           NTL::xdouble size = NTL::xdouble(-1.0),
                           NTL::xdouble factor = NTL::xdouble(-1.0),
@@ -1157,13 +1167,15 @@ public:
    * @deprecated This function is deprecated in favor of a newer API.
    * Please use `Ctxt::operator*=(const PtxtArray& ptxt)` instead.
    **/
-  // [[deprecated]]
+  [[deprecated(
+      "Please use Ctxt::operator*=(const Ptxt<Scheme>& ptxt) instead.")]]
   void multByConstantCKKS(const Ptxt<CKKS>& ptxt);
   /**
    * @deprecated This function is deprecated in favor of a newer API.
    * Please use `Ctxt::operator*=(const PtxtArray& ptxt)` instead.
    **/
-  // [[deprecated]]
+  [[deprecated(
+      "Please use Ctxt::operator*=(const PtxtArray& ptxt) instead.")]]
   void multByConstantCKKS(const std::vector<std::complex<double>>& ptxt);
 
   //! Convenience method: XOR and nXOR with arbitrary plaintext space:
@@ -1394,7 +1406,7 @@ public:
    * @brief Returns log(noiseBound) - log(q)
    * @deprecated This is deprecated. Please use `Ctxt::capacity()` instead.
    **/
-  // [[deprecated]] // use capacity()
+  [[deprecated("Please use Ctxt::capacity() instead.")]]
   double log_of_ratio() const
   {
     double logNoise =

--- a/src/Ctxt.cpp
+++ b/src/Ctxt.cpp
@@ -1060,11 +1060,14 @@ void Ctxt::addConstantCKKS(const NTL::ZZX& poly,
 
 Ctxt& Ctxt::operator*=(const NTL::ZZX& poly)
 {
-  if (isCKKS())
-    multByConstantCKKS(poly);
-  else
-    multByConstant(poly);
-  return *this;
+  // NOTE: This function has been depcreated.
+  //  if (isCKKS())
+  //    multByConstantCKKS(poly);
+  //  else
+  //    multByConstant(poly);
+  //  return *this;
+  PtxtArray pa(getContext(), poly);
+  return *this *= pa;
 }
 
 void Ctxt::addConstantCKKS(const std::vector<std::complex<double>>& other)
@@ -1072,17 +1075,19 @@ void Ctxt::addConstantCKKS(const std::vector<std::complex<double>>& other)
   // VJS-FIXME: this routine has a number of issues and should
   // be deprecated in favor of the new EncodedPtxt-based routines
 
-  NTL::ZZX poly;
-  double factor = getContext().getEA().getCx().encode(poly, other);
-  // VJS-NOTE: maybe this encdoing routine should also return
-  // the rounding error...we kind of need this value
-
-  double size = Norm(other);
-
-  if (size == 0.0)
-    return;
-
-  addConstantCKKS(poly, NTL::xdouble{size}, NTL::xdouble{factor});
+  //  NTL::ZZX poly;
+  //  double factor = getContext().getEA().getCx().encode(poly, other);
+  //  // VJS-NOTE: maybe this encdoing routine should also return
+  //  // the rounding error...we kind of need this value
+  //
+  //  double size = Norm(other);
+  //
+  //  if (size == 0.0)
+  //    return;
+  //
+  //  addConstantCKKS(poly, NTL::xdouble{size}, NTL::xdouble{factor});
+  PtxtArray pa(getContext(), other);
+  *this += pa;
 }
 
 void Ctxt::addConstantCKKS(const NTL::ZZ& c)
@@ -1135,7 +1140,9 @@ void Ctxt::addConstantCKKS(std::pair<long, long> num)
 
 void Ctxt::addConstantCKKS(const Ptxt<CKKS>& ptxt)
 {
-  addConstantCKKS(ptxt.getSlotRepr());
+  // This function has been deprecated.
+  // addConstantCKKS(ptxt.getSlotRepr());
+  *this += ptxt;
 }
 
 // Add at least one prime to the primeSet of c
@@ -1866,17 +1873,19 @@ void Ctxt::multByConstantCKKS(const std::vector<std::complex<double>>& other)
   // be deprecated in favor of the new EncodedPtxt-based routines
 
   // NOTE: some replicated logic here and in addConstantCKKS...
-  NTL::ZZX poly;
-  double factor = getContext().getEA().getCx().encode(poly, other);
-  // VJS-NOTE: why does encode with ZZX not require a size arg?
-
-  double size = Norm(other);
-
-  // VJS-NOTE: if size==0 we should just do thus->clear()
-  if (size == 0.0)
-    size = 1.0;
-
-  multByConstantCKKS(poly, NTL::xdouble{size}, NTL::xdouble{factor});
+  //  NTL::ZZX poly;
+  //  double factor = getContext().getEA().getCx().encode(poly, other);
+  //  // VJS-NOTE: why does encode with ZZX not require a size arg?
+  //
+  //  double size = Norm(other);
+  //
+  //  // VJS-NOTE: if size==0 we should just do thus->clear()
+  //  if (size == 0.0)
+  //    size = 1.0;
+  //
+  //  multByConstantCKKS(poly, NTL::xdouble{size}, NTL::xdouble{factor});
+  PtxtArray pa(getContext(), other);
+  *this *= pa;
 }
 
 void Ctxt::multByConstantCKKS(const DoubleCRT& dcrt,
@@ -1916,7 +1925,9 @@ void Ctxt::multByConstantCKKS(const DoubleCRT& dcrt,
 
 void Ctxt::multByConstantCKKS(const Ptxt<CKKS>& ptxt)
 {
-  multByConstantCKKS(ptxt.getSlotRepr());
+  // This function has been deprecated.
+  // multByConstantCKKS(ptxt.getSlotRepr());
+  *this *= ptxt;
 }
 
 //=========== new multByConstant interface =========

--- a/src/EaCx.cpp
+++ b/src/EaCx.cpp
@@ -419,9 +419,9 @@ void EncryptedArrayCx::random(std::vector<cx_double>& array, double rad) const
 void EncryptedArrayCx::extractRealPart(Ctxt& c) const
 {
   Ctxt tmp = c;
-  tmp.complexConj();         // the complex conjugate of c
-  c += tmp;                  // c + conj(c) = 2*real(c)
-  c.multByConstantCKKS(0.5); // divide by two
+  tmp.complexConj(); // the complex conjugate of c
+  c += tmp;          // c + conj(c) = 2*real(c)
+  c *= 0.5;          // divide by two
 }
 
 // Note: If called with dcrt==nullptr, it will perform FFT's when
@@ -446,7 +446,7 @@ void EncryptedArrayCx::extractImPart(Ctxt& c, DoubleCRT* iDcrtPtr) const
     iDcrtPtr = &tmpDcrt;
   }
   c.multByConstantCKKS(*iDcrtPtr); // multiply by i
-  c.multByConstantCKKS(0.5);       // divide by two
+  c *= 0.5;                        // divide by two
 }
 
 void EncryptedArrayCx::buildLinPolyCoeffs(std::vector<zzX>& C,

--- a/tests/TestCKKS.cpp
+++ b/tests/TestCKKS.cpp
@@ -225,7 +225,7 @@ TEST_P(TestCKKS, addingPolyConstantToCiphertextWorks)
 {
   helib::Ctxt c1(publicKey);
   std::vector<std::complex<double>> vd1, vd2, vd3;
-  NTL::ZZX poly;
+  helib::EncodedPtxt eptxt; // Containing holding a polynomial i.e. NTL::ZZX
   NTL::xdouble rf, pm;
 
   ea.random(vd1);
@@ -233,8 +233,9 @@ TEST_P(TestCKKS, addingPolyConstantToCiphertextWorks)
   ea.encrypt(c1, publicKey, vd1);
   rf = c1.getRatFactor();
   pm = c1.getPtxtMag();
-  ea.encode(poly, vd2, /*size=*/1.0);
-  c1.addConstantCKKS(poly);
+  helib::PtxtArray pa(context, vd2);
+  pa.encode(eptxt, /*mag=*/1.0); // Encode polynomial
+  c1 += eptxt;
   ea.decrypt(c1, secretKey, vd3);
 
   add(vd1, vd2);
@@ -250,7 +251,7 @@ TEST_P(TestCKKS, addingNegatedPolyConstantToCiphertextWorks)
 {
   helib::Ctxt c1(publicKey);
   std::vector<std::complex<double>> vd1, vd2, vd3;
-  NTL::ZZX poly;
+  helib::EncodedPtxt eptxt; // Containing holding a polynomial i.e. NTL::ZZX
   NTL::xdouble rf, pm;
 
   ea.random(vd1);
@@ -259,8 +260,9 @@ TEST_P(TestCKKS, addingNegatedPolyConstantToCiphertextWorks)
   ea.encrypt(c1, publicKey, vd1);
   rf = c1.getRatFactor();
   pm = c1.getPtxtMag();
-  ea.encode(poly, vd2, /*size=*/1.0);
-  c1.addConstantCKKS(poly);
+  helib::PtxtArray pa(context, vd2);
+  pa.encode(eptxt, /*mag=*/1.0); // Encode polynomial
+  c1 += eptxt;
   ea.decrypt(c1, secretKey, vd3);
 
   add(vd1, vd2);
@@ -277,7 +279,7 @@ TEST_P(TestCKKS, multiplyingPolyConstantToCiphertextWorks)
 {
   helib::Ctxt c1(publicKey);
   std::vector<std::complex<double>> vd1, vd2, vd3;
-  NTL::ZZX poly;
+  helib::EncodedPtxt eptxt; // Container holding a polynomial i.e. NTL::ZZX
   NTL::xdouble rf, pm;
 
   ea.random(vd1);
@@ -285,8 +287,9 @@ TEST_P(TestCKKS, multiplyingPolyConstantToCiphertextWorks)
   ea.encrypt(c1, publicKey, vd1);
   rf = c1.getRatFactor();
   pm = c1.getPtxtMag();
-  ea.encode(poly, vd2, /*size=*/1.0);
-  c1.multByConstantCKKS(poly);
+  helib::PtxtArray pa(context, vd2);
+  pa.encode(eptxt, /*mag*/ 1.0); // Encode polynomial
+  c1 *= eptxt;
   ea.decrypt(c1, secretKey, vd3);
 
   mul(vd1, vd2);
@@ -313,7 +316,7 @@ TEST_P(TestCKKS, addingDoubleToCiphertextWorks)
   ea.encrypt(c1, publicKey, vd1);
   rf = c1.getRatFactor();
   pm = c1.getPtxtMag();
-  c1.addConstantCKKS(vd[0]);
+  c1 += vd[0]; // Same as depcrecated c1.addConstantCKKS(vd[0]);
   ea.decrypt(c1, secretKey, vd2);
 
   add(vd1, vd[0]);
@@ -338,8 +341,7 @@ TEST_P(TestCKKS, multiplyingDoubleToCiphertextWorks)
   ea.encrypt(c1, publicKey, vd1);
   rf = c1.getRatFactor();
   pm = c1.getPtxtMag();
-  c1.multByConstantCKKS(vd[0]);
-  // c1 *= vd[0];
+  c1 *= vd[0]; // Same as deprecated c1.multByConstantCKKS(vd[0]);
   ea.decrypt(c1, secretKey, vd2);
 
   mul(vd1, vd[0]);
@@ -564,7 +566,9 @@ TEST_P(
   ea.random(vd2);
   ea.encrypt(c1, publicKey, vd1);
   ea.encrypt(c2, publicKey, vd2);
-  c1.multByConstantCKKS(std::make_pair<long, long>(-5, 2));
+  // Same as deprecated function
+  // c1.multByConstantCKKS(std::make_pair<long, long>(-5, 2));
+  c1 *= -5.0 / 2.0;
   c1 += c2;
   ea.decrypt(c1, secretKey, vd4);
 
@@ -585,7 +589,7 @@ TEST_P(TestCKKS, multiplyingByConstantNeverProducesNegativeRatFactor)
 
   ea.random(vd1);
   ea.encrypt(c1, publicKey, vd1);
-  c1.multByConstantCKKS(-2.0);
+  c1 *= -2.0; // Same as deprecated c1.multByConstantCKKS(-2.0);
 
   EXPECT_GT(c1.getRatFactor(), 0);
 }
@@ -599,7 +603,8 @@ TEST_P(TestCKKS, multiplyBySmallNegativeConstantFollowedByOperationWorks)
   ea.random(vd2);
   ea.encrypt(c1, publicKey, vd1);
   ea.encrypt(c2, publicKey, vd2);
-  c1.multByConstantCKKS(-2.0 / 10.0);
+  // Same as deprecated c1.multByConstantCKKS(-2.0 / 10.0);
+  c1 *= (-2.0 / 10.0);
   c1 -= c2;
   ea.decrypt(c1, secretKey, vd3);
 

--- a/tests/TestCtxt.cpp
+++ b/tests/TestCtxt.cpp
@@ -122,12 +122,16 @@ TEST_P(TestCtxt, timesEqualsWithLongWorks)
   EXPECT_EQ(decrypted_result, expected_result);
 }
 
-TEST_P(TestCtxt, timesEqualsWithZZXWorks)
+TEST_P(TestCtxt, timesEqualsWithEncodedPtxtWorks)
 {
   helib::Ptxt<helib::BGV> ptxt(context, std::vector<long>(ea.size(), 5));
   helib::Ctxt ctxt(publicKey);
   publicKey.Encrypt(ctxt, ptxt);
-  ctxt *= NTL::ZZX(2l);
+
+  helib::PtxtArray pa(context, NTL::ZZX(2l));
+  helib::EncodedPtxt eptxt; // Container for holding a polynomial i.e. NTL::ZZX
+  pa.encode(eptxt);
+  ctxt *= eptxt; // Same as the deprecated function ctxt *= NTL::ZZX(2l);
 
   helib::Ptxt<helib::BGV> expected_result(context,
                                           std::vector<long>(ea.size(), 10));

--- a/tests/TestPtxt.cpp
+++ b/tests/TestPtxt.cpp
@@ -1180,38 +1180,41 @@ TEST_P(TestPtxtCKKS, plusEqualsWithCiphertextWorks)
   }
 }
 
-TEST_P(TestPtxtCKKS, addConstantCKKSWithCiphertextWorks)
-{
-  context.buildModChain(150, 2);
-  helib::SecKey secret_key(context);
-  secret_key.GenSecKey();
-  const helib::PubKey& public_key(secret_key);
-
-  // Encrypt the augend, addend is plaintext
-  std::vector<std::complex<double>> augend_data(context.getEA().size());
-  std::vector<std::complex<double>> addend_data(context.getEA().size());
-  for (long i = 0; i < helib::lsize(augend_data); ++i) {
-    augend_data[i] = {i / 70.0, -i * 10.5};
-    addend_data[i] = {-i / 10.0, i * 0.8};
-  }
-  helib::Ptxt<helib::CKKS> augend_ptxt(context, augend_data);
-  helib::Ptxt<helib::CKKS> addend(context, addend_data);
-  helib::Ctxt augend(public_key);
-  public_key.Encrypt(augend, augend_ptxt);
-
-  augend.addConstantCKKS(addend);
-  augend_ptxt += addend;
-
-  // augend_ptxt and augend should now match
-  helib::Ptxt<helib::CKKS> result(context);
-  secret_key.Decrypt(result, augend);
-  EXPECT_EQ(result.size(), augend_ptxt.size());
-  for (std::size_t i = 0; i < result.size(); ++i) {
-    EXPECT_NEAR(std::norm(result[i] - augend_ptxt[i]),
-                0,
-                post_encryption_epsilon);
-  }
-}
+// This test has been commented out as the function
+// Ctxt::addConstantCKKS(Ptxt& ptxt) is deprecated in favor for the above API
+// Ctxt::operator+=(const Ptxt<Scheme>& ptxt).
+// TEST_P(TestPtxtCKKS, addConstantCKKSWithCiphertextWorks)
+// {
+//  context.buildModChain(150, 2);
+//  helib::SecKey secret_key(context);
+//  secret_key.GenSecKey();
+//  const helib::PubKey& public_key(secret_key);
+//
+//  // Encrypt the augend, addend is plaintext
+//  std::vector<std::complex<double>> augend_data(context.getEA().size());
+//  std::vector<std::complex<double>> addend_data(context.getEA().size());
+//  for (long i = 0; i < helib::lsize(augend_data); ++i) {
+//    augend_data[i] = {i / 70.0, -i * 10.5};
+//    addend_data[i] = {-i / 10.0, i * 0.8};
+//  }
+//  helib::Ptxt<helib::CKKS> augend_ptxt(context, augend_data);
+//  helib::Ptxt<helib::CKKS> addend(context, addend_data);
+//  helib::Ctxt augend(public_key);
+//  public_key.Encrypt(augend, augend_ptxt);
+//
+//  augend.addConstantCKKS(addend); // Deprecated in favor of augend += addend;
+//  augend_ptxt += addend;
+//
+//  // augend_ptxt and augend should now match
+//  helib::Ptxt<helib::CKKS> result(context);
+//  secret_key.Decrypt(result, augend);
+//  EXPECT_EQ(result.size(), augend_ptxt.size());
+//  for (std::size_t i = 0; i < result.size(); ++i) {
+//    EXPECT_NEAR(std::norm(result[i] - augend_ptxt[i]),
+//                0,
+//                post_encryption_epsilon);
+//  }
+// }
 
 TEST_P(TestPtxtCKKS, minusEqualsWithCiphertextWorks)
 {
@@ -1246,39 +1249,42 @@ TEST_P(TestPtxtCKKS, minusEqualsWithCiphertextWorks)
   }
 }
 
-TEST_P(TestPtxtCKKS, multByConstantCKKSFromCiphertextWorks)
-{
-  context.buildModChain(150, 2);
-  helib::SecKey secret_key(context);
-  secret_key.GenSecKey();
-  const helib::PubKey& public_key(secret_key);
-
-  // Encrypt the multiplier, multiplicand is plaintext
-  std::vector<std::complex<double>> multiplier_data(context.getEA().size());
-  std::vector<std::complex<double>> multiplicand_data(context.getEA().size());
-  for (long i = 0; i < helib::lsize(multiplier_data); ++i) {
-    multiplier_data[i] = {i * 4.5, -i * i / 12.5};
-    multiplicand_data[i] = {(i - 2.5) / 3.5, i * 4.2};
-  }
-  helib::Ptxt<helib::CKKS> multiplier_ptxt(context, multiplier_data);
-  helib::Ptxt<helib::CKKS> multiplicand(context, multiplicand_data);
-
-  helib::Ctxt multiplier(public_key);
-  public_key.Encrypt(multiplier, multiplier_ptxt);
-
-  multiplier.multByConstantCKKS(multiplicand);
-  multiplier_ptxt *= multiplicand;
-
-  // multiplier_ptxt and multiplier should now match
-  helib::Ptxt<helib::CKKS> result(context);
-  secret_key.Decrypt(result, multiplier);
-  EXPECT_EQ(result.size(), multiplier_ptxt.size());
-  for (std::size_t i = 0; i < result.size(); ++i) {
-    EXPECT_NEAR(std::norm(result[i] - multiplier_ptxt[i]),
-                0,
-                post_encryption_epsilon);
-  }
-}
+// This test has been commented out as the function
+// Ctxt::multByConstantCKKS(Ptxt& ptxt) is deprecated in favor for the above API
+// Ctxt::operator*=(const Ptxt<Scheme>& ptxt).
+// TEST_P(TestPtxtCKKS, multByConstantCKKSFromCiphertextWorks)
+// {
+//  context.buildModChain(150, 2);
+//  helib::SecKey secret_key(context);
+//  secret_key.GenSecKey();
+//  const helib::PubKey& public_key(secret_key);
+//
+//  // Encrypt the multiplier, multiplicand is plaintext
+//  std::vector<std::complex<double>> multiplier_data(context.getEA().size());
+//  std::vector<std::complex<double>> multiplicand_data(context.getEA().size());
+//  for (long i = 0; i < helib::lsize(multiplier_data); ++i) {
+//    multiplier_data[i] = {i * 4.5, -i * i / 12.5};
+//    multiplicand_data[i] = {(i - 2.5) / 3.5, i * 4.2};
+//  }
+//  helib::Ptxt<helib::CKKS> multiplier_ptxt(context, multiplier_data);
+//  helib::Ptxt<helib::CKKS> multiplicand(context, multiplicand_data);
+//
+//  helib::Ctxt multiplier(public_key);
+//  public_key.Encrypt(multiplier, multiplier_ptxt);
+//
+//  multiplier.multByConstantCKKS(multiplicand);
+//  multiplier_ptxt *= multiplicand;
+//
+//  // multiplier_ptxt and multiplier should now match
+//  helib::Ptxt<helib::CKKS> result(context);
+//  secret_key.Decrypt(result, multiplier);
+//  EXPECT_EQ(result.size(), multiplier_ptxt.size());
+//  for (std::size_t i = 0; i < result.size(); ++i) {
+//    EXPECT_NEAR(std::norm(result[i] - multiplier_ptxt[i]),
+//                0,
+//                post_encryption_epsilon);
+//  }
+// }
 
 TEST_P(TestPtxtCKKS, timesEqualsFromCiphertextWorks)
 {


### PR DESCRIPTION
This is the second part of the deprecated functions work.
* Added the C++ [[deprecated]] tag to deprecated functions with recommendations of alternative functions.
* Use of these deprecated APIs should now produce compiler warnings.