### PR TITLE
PGFFT: Require __FMA__ directive for FMA operations

### DIFF
--- a/src/PGFFT.cpp
+++ b/src/PGFFT.cpp
@@ -42,7 +42,7 @@ See below for more details.
 //#warning "HAVE_AVX"
 #endif
 
-#ifdef __AVX2__
+#if defined(__AVX2__) && defined(__FMA__)
 #define HAVE_AVX2
 //#warning "HAVE_AVX2"
 #endif


### PR DESCRIPTION
When compiling in a VirtualBox VM, AVX2 instructions are supported but
FMA instructions are not.  In such case, compiling PGFFT.cpp fails with:

```
/usr/lib/gcc/x86_64-linux-gnu/9/include/fmaintrin.h:239:1: error: inlining failed in call to always_inline '__m256d_mm256_fmaddsub_pd(__m256d, __m256d, __m256d)': target specific option mismatch
  239 | _mm256_fmaddsub_pd (__m256d __A, __m256d __B, __m256d __C)
      | ^~~~~~~~~~~~~~~~~~
/home/user/work/HElib-2.0.0/src/PGFFT.cpp:330:51: note: called from here
  330 | { return _mm256_fmaddsub_pd(a.data, b.data, c.data); }
      |
```

This fix narrows the detection so that only when both `__AVX2__` and
`__FMA__` are defined then the special FMA implementation will be used.

Note that I *didn't* replace `HAVE_AVX2` to `HAVE_AVX2_AND_FMA` throughout the file.

Fix #426

Signed-off-by: Dov Murik <dov.murik1@il.ibm.com>