### PR TITLE
Support saving only the secret key

### DIFF
--- a/include/helib/keys.h
+++ b/include/helib/keys.h
@@ -427,12 +427,29 @@ public:
   void writeTo(std::ostream& str) const;
 
   /**
+   * @brief Write out only the secret key part of the `SecKey` object in binary format.
+   * @param str Output `std::ostream`.
+   **/
+  void writeOnlySecretKeyTo(std::ostream& str) const;
+
+
+  /**
    * @brief Read from the stream the serialized `SecKey` object in binary
    * format.
    * @param str Input `std::istream`.
    * @return The deserialized `SecKey` object.
    **/
   static SecKey readFrom(std::istream& str, const Context& context);
+
+  /**
+   * @brief Read from the stream only the serialized secret key in binary
+   * format and add it to a PubKey to get a SecKey object.
+   * @param str Input `std::istream`.
+   * @param pubKey Public key matching the secret key.
+   * @return The deserialized `SecKey` object.
+   **/
+  static SecKey readOnlySecretKeyFrom(std::istream& str, const PubKey &pubKey);
+
 
   /**
    * @brief Write out the secret key (`SecKey`) object to the output

--- a/tests/TestBinIO.cpp
+++ b/tests/TestBinIO.cpp
@@ -394,22 +394,23 @@ TEST_P(TestBinIO_BGV, throwsWhenPostSecretKeyEyeCatcherNotFound)
 
 TEST_P(TestBinIO_BGV, readKeysFromDeserializeCorrectly)
 {
-  std::stringstream str;
-
-  EXPECT_NO_THROW(publicKey.writeTo(str));
-
-  helib::PubKey deserialized_pk = helib::PubKey::readFrom(str, context);
-
+  std::stringstream strPub;
+  EXPECT_NO_THROW(publicKey.writeTo(strPub));
+  helib::PubKey deserialized_pk = helib::PubKey::readFrom(strPub, context);
   EXPECT_EQ(publicKey, deserialized_pk);
 
-  str.str("");
-  str.clear();
+  std::stringstream strPubSec;
+  EXPECT_NO_THROW(secretKey.writeTo(strPubSec));
+  helib::SecKey deserialized_skpk = helib::SecKey::readFrom(strPubSec, context);
+  EXPECT_EQ(secretKey, deserialized_skpk);
 
-  EXPECT_NO_THROW(secretKey.writeTo(str));
-
-  helib::SecKey deserialized_sk = helib::SecKey::readFrom(str, context);
-
+  std::stringstream strSec;
+  EXPECT_NO_THROW(secretKey.writeOnlySecretKeyTo(strSec));
+  helib::SecKey deserialized_sk = helib::SecKey::readOnlySecretKeyFrom(strSec, deserialized_pk);
   EXPECT_EQ(secretKey, deserialized_sk);
+
+  // check that writing SK is smaller than PK+SK
+  EXPECT_TRUE(2*strSec.tellp() < strPubSec.tellp());
 }
 
 TEST_P(TestBinIO_BGV, readKeyPtrsFromDeserializeCorrectly)
@@ -800,22 +801,24 @@ TEST_P(TestBinIO_CKKS, throwsWhenPostSecretKeyEyeCatcherNotFound)
 
 TEST_P(TestBinIO_CKKS, readKeysFromDeserializeCorrectly)
 {
-  std::stringstream str;
-
-  EXPECT_NO_THROW(publicKey.writeTo(str));
-
-  helib::PubKey deserialized_pk = helib::PubKey::readFrom(str, context);
-
+  std::stringstream strPub;
+  EXPECT_NO_THROW(publicKey.writeTo(strPub));
+  helib::PubKey deserialized_pk = helib::PubKey::readFrom(strPub, context);
   EXPECT_EQ(publicKey, deserialized_pk);
 
-  str.str("");
-  str.clear();
+  std::stringstream strPubSec;
+  EXPECT_NO_THROW(secretKey.writeTo(strPubSec));
+  helib::SecKey deserialized_skpk = helib::SecKey::readFrom(strPubSec, context);
+  EXPECT_EQ(secretKey, deserialized_skpk);
 
-  EXPECT_NO_THROW(secretKey.writeTo(str));
-
-  helib::SecKey deserialized_sk = helib::SecKey::readFrom(str, context);
-
+  std::stringstream strSec;
+  EXPECT_NO_THROW(secretKey.writeOnlySecretKeyTo(strSec));
+  helib::SecKey deserialized_sk = helib::SecKey::readOnlySecretKeyFrom(strSec, deserialized_pk);
   EXPECT_EQ(secretKey, deserialized_sk);
+
+  // check that writing SK is smaller than PK+SK
+  // Here we assume that size(SK)<size(PK)
+  EXPECT_TRUE(2*strSec.tellp() < strPubSec.tellp());
 }
 
 TEST_P(TestBinIO_CKKS, readKeyPtrsFromDeserializeCorrectly)


### PR DESCRIPTION
Add new API calls (`writeOnlySecretKeyTo`, `readOnlySecretKeyFrom`) to save/load just the secret key, resulting in a much smaller file.

Author: @HayimShaul
cc: @aehud
