### PR TITLE
Add explicit <optional> header

### DIFF
--- a/include/helib/Context.h
+++ b/include/helib/Context.h
@@ -15,6 +15,7 @@
  * @file Context.h
  * @brief Keeps the parameters of an instance of the cryptosystem
  **/
+#include <optional>
 #include <helib/PAlgebra.h>
 #include <helib/CModulus.h>
 #include <helib/IndexSet.h>


### PR DESCRIPTION
Hi there 👋, I'm reaching out on behalf of the team at the Homebrew package manager. When compiling with GCC 11 on Linux, it appears that the `<optional>` header must be explicitly added in order for compilation to succeed. Without it, there's errors like this:
```
[  4%] Building CXX object src/CMakeFiles/helib.dir/binaryArith.cpp.o
cd /tmp/helib-20210729-8183-1rf2hiw/HElib-2.1.0/build/src && /home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/shims/linux/super/g++-11 -DHELIB_BOOT_THREADS -DHELIB_THREADS -Dhelib_EXPORTS -I/tmp/helib-20210729-8183-1rf2hiw/HElib-2.1.0/dependencies/json -I/tmp/helib-20210729-8183-1rf2hiw/HElib-2.1.0/include -I/tmp/helib-20210729-8183-1rf2hiw/HElib-2.1.0/build/src -isystem /home/linuxbrew/.linuxbrew/include/NTL/.. -O3 -DNDEBUG -fPIC -march=native -Wall -Wpedantic -Wextra -Werror -std=c++17 -MD -MT src/CMakeFiles/helib.dir/BenesNetwork.cpp.o -MF CMakeFiles/helib.dir/BenesNetwork.cpp.o.d -o CMakeFiles/helib.dir/BenesNetwork.cpp.o -c /tmp/helib-20210729-8183-1rf2hiw/HElib-2.1.0/src/BenesNetwork.cpp
cd /tmp/helib-20210729-8183-1rf2hiw/HElib-2.1.0/build/src && /home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/shims/linux/super/g++-11 -DHELIB_BOOT_THREADS -DHELIB_THREADS -Dhelib_EXPORTS -I/tmp/helib-20210729-8183-1rf2hiw/HElib-2.1.0/dependencies/json -I/tmp/helib-20210729-8183-1rf2hiw/HElib-2.1.0/include -I/tmp/helib-20210729-8183-1rf2hiw/HElib-2.1.0/build/src -isystem /home/linuxbrew/.linuxbrew/include/NTL/.. -O3 -DNDEBUG -fPIC -march=native -Wall -Wpedantic -Wextra -Werror -std=c++17 -MD -MT src/CMakeFiles/helib.dir/binaryArith.cpp.o -MF CMakeFiles/helib.dir/binaryArith.cpp.o.d -o CMakeFiles/helib.dir/binaryArith.cpp.o -c /tmp/helib-20210729-8183-1rf2hiw/HElib-2.1.0/src/binaryArith.cpp
In file included from /tmp/helib-20210729-8183-1rf2hiw/HElib-2.1.0/include/helib/EncryptedArray.h:26,
                 from /tmp/helib-20210729-8183-1rf2hiw/HElib-2.1.0/src/BenesNetwork.cpp:13:
/tmp/helib-20210729-8183-1rf2hiw/HElib-2.1.0/include/helib/Context.h:211:22: error: 'optional' in namespace 'std' does not name a template type
  211 |           const std::optional<ModChainParams>& mparams,
      |                      ^~~~~~~~
/tmp/helib-20210729-8183-1rf2hiw/HElib-2.1.0/include/helib/Context.h:27:1: note: 'std::optional' is defined in header '<optional>'; did you forget to '#include <optional>'?
   26 | #include <helib/scheme.h>
  +++ |+#include <optional>
   27 | #include <helib/JsonWrapper.h>
/tmp/helib-20210729-8183-1rf2hiw/HElib-2.1.0/include/helib/Context.h:211:30: error: expected ',' or '...' before '<' token
  211 |           const std::optional<ModChainParams>& mparams,
      |                              ^
/tmp/helib-20210729-8183-1rf2hiw/HElib-2.1.0/include/helib/Context.h:1056:24: error: 'optional' is not a member of 'std'
 1056 |   const std::pair<std::optional<Context::ModChainParams>,
      |                        ^~~~~~~~
/tmp/helib-20210729-8183-1rf2hiw/HElib-2.1.0/include/helib/Context.h:1056:24: note: 'std::optional' is defined in header '<optional>'; did you forget to '#include <optional>'?
/tmp/helib-20210729-8183-1rf2hiw/HElib-2.1.0/include/helib/Context.h:1056:56: error: wrong number of template arguments (1, should be 2)
 1056 |   const std::pair<std::optional<Context::ModChainParams>,
      |                                                        ^
In file included from /home/linuxbrew/.linuxbrew/Cellar/gcc/11.1.0_1/include/c++/11.1.0/utility:70,
                 from /home/linuxbrew/.linuxbrew/include/NTL/../NTL/tools.h:13,
                 from /home/linuxbrew/.linuxbrew/include/NTL/../NTL/ZZ.h:19,
                 from /home/linuxbrew/.linuxbrew/include/NTL/../NTL/lzz_p.h:5,
                 from /home/linuxbrew/.linuxbrew/include/NTL/../NTL/lzz_pXFactoring.h:6,
                 from /tmp/helib-20210729-8183-1rf2hiw/HElib-2.1.0/src/BenesNetwork.cpp:12:
/home/linuxbrew/.linuxbrew/Cellar/gcc/11.1.0_1/include/c++/11.1.0/bits/stl_pair.h:211:12: note: provided for 'template<class _T1, class _T2> struct std::pair'
  211 |     struct pair
      |            ^~~~
In file included from /tmp/helib-20210729-8183-1rf2hiw/HElib-2.1.0/include/helib/EncryptedArray.h:26,
                 from /tmp/helib-20210729-8183-1rf2hiw/HElib-2.1.0/src/BenesNetwork.cpp:13:
/tmp/helib-20210729-8183-1rf2hiw/HElib-2.1.0/include/helib/Context.h:1056:57: error: expected unqualified-id before ',' token
 1056 |   const std::pair<std::optional<Context::ModChainParams>,
      |                                                         ^
In file included from /tmp/helib-20210729-8183-1rf2hiw/HElib-2.1.0/include/helib/EncryptedArray.h:26,
                 from /tmp/helib-20210729-8183-1rf2hiw/HElib-2.1.0/include/helib/binaryArith.h:18,
                 from /tmp/helib-20210729-8183-1rf2hiw/HElib-2.1.0/src/binaryArith.cpp:25:
/tmp/helib-20210729-8183-1rf2hiw/HElib-2.1.0/include/helib/Context.h:211:22: error: 'optional' in namespace 'std' does not name a template type
  211 |           const std::optional<ModChainParams>& mparams,
      |                      ^~~~~~~~
/tmp/helib-20210729-8183-1rf2hiw/HElib-2.1.0/include/helib/Context.h:27:1: note: 'std::optional' is defined in header '<optional>'; did you forget to '#include <optional>'?
   26 | #include <helib/scheme.h>
  +++ |+#include <optional>
   27 | #include <helib/JsonWrapper.h>
/tmp/helib-20210729-8183-1rf2hiw/HElib-2.1.0/include/helib/Context.h:211:30: error: expected ',' or '...' before '<' token
  211 |           const std::optional<ModChainParams>& mparams,
      |                              ^
/tmp/helib-20210729-8183-1rf2hiw/HElib-2.1.0/include/helib/Context.h:1056:24: error: 'optional' is not a member of 'std'
 1056 |   const std::pair<std::optional<Context::ModChainParams>,
      |                        ^~~~~~~~
/tmp/helib-20210729-8183-1rf2hiw/HElib-2.1.0/include/helib/Context.h:1056:24: note: 'std::optional' is defined in header '<optional>'; did you forget to '#include <optional>'?
/tmp/helib-20210729-8183-1rf2hiw/HElib-2.1.0/include/helib/Context.h:1056:56: error: wrong number of template arguments (1, should be 2)
 1056 |   const std::pair<std::optional<Context::ModChainParams>,
      |                                                        ^
In file included from /home/linuxbrew/.linuxbrew/Cellar/gcc/11.1.0_1/include/c++/11.1.0/bits/stl_algobase.h:64,
                 from /home/linuxbrew/.linuxbrew/Cellar/gcc/11.1.0_1/include/c++/11.1.0/bits/stl_tree.h:63,
                 from /home/linuxbrew/.linuxbrew/Cellar/gcc/11.1.0_1/include/c++/11.1.0/map:60,
                 from /tmp/helib-20210729-8183-1rf2hiw/HElib-2.1.0/src/binaryArith.cpp:18:
/home/linuxbrew/.linuxbrew/Cellar/gcc/11.1.0_1/include/c++/11.1.0/bits/stl_pair.h:211:12: note: provided for 'template<class _T1, class _T2> struct std::pair'
  211 |     struct pair
      |            ^~~~
In file included from /tmp/helib-20210729-8183-1rf2hiw/HElib-2.1.0/include/helib/EncryptedArray.h:26,
                 from /tmp/helib-20210729-8183-1rf2hiw/HElib-2.1.0/include/helib/binaryArith.h:18,
                 from /tmp/helib-20210729-8183-1rf2hiw/HElib-2.1.0/src/binaryArith.cpp:25:
/tmp/helib-20210729-8183-1rf2hiw/HElib-2.1.0/include/helib/Context.h:1056:57: error: expected unqualified-id before ',' token
 1056 |   const std::pair<std::optional<Context::ModChainParams>,
      |                                                         ^
make[2]: *** [src/CMakeFiles/helib.dir/build.make:79: src/CMakeFiles/helib.dir/BenesNetwork.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[2]: *** [src/CMakeFiles/helib.dir/build.make:93: src/CMakeFiles/helib.dir/binaryArith.cpp.o] Error 1
make[2]: Leaving directory '/tmp/helib-20210729-8183-1rf2hiw/HElib-2.1.0/build'
make[1]: *** [CMakeFiles/Makefile2:101: src/CMakeFiles/helib.dir/all] Error 2
make[1]: Leaving directory '/tmp/helib-20210729-8183-1rf2hiw/HElib-2.1.0/build'
make: *** [Makefile:139: all] Error 2
```

Of interest,

```
note: 'std::optional' is defined in header '<optional>'; did you forget to '#include <optional>'?
```

Adding the mentioned header fixed the compilation in our case.

Downstream issue: https://github.com/Homebrew/homebrew-core/pull/82058